### PR TITLE
Added paths + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ There are currently three options available:
   blue magenta cyan bright-red bright-green bright-yellow bright-blue
   bright-magenta bright-cyan bright-white.
 
+- `:paths` -
+  a seq of paths to check for changes (defaults to the project's root).
+
 ## License
 
 Copyright © 2014 James Reeves


### PR DESCRIPTION
Hi, I added a `:paths` option that is similar to the [other pull request](https://github.com/weavejester/lein-auto/pull/1). The main difference is that it uses a project's root as the default. Does this look OK?

Thanks for making this awesome plugin!