### PR TITLE
Enable auto to resolve lein path kws from the project

### DIFF
--- a/src/leiningen/auto.clj
+++ b/src/leiningen/auto.clj
@@ -54,20 +54,25 @@
 (def default-config
   {:file-pattern #"\.(clj|cljs|cljx|cljc)$"
    :wait-time    50
-   :log-color    :magenta})
+   :log-color    :magenta
+   :paths        [:source-paths :java-source-paths :test-paths]})
 
-(defn default-paths [project]
-  (concat (:source-paths project)
-          (:java-source-paths project)
-          (:test-paths project)))
+(defn compute-config [project config]
+  (-> config
+      (update :paths (fn [paths]
+                       (mapcat (fn [path-or-key]
+                                 (if (keyword? path-or-key)
+                                   (get project path-or-key)
+                                   [path-or-key]))
+                               paths)))))
 
 (defn auto
   "Executes the given task every time a file in the project is modified."
   [project task & args]
-  (let [config (merge default-config
-                      {:paths (default-paths project)}
-                      (get-in project [:auto :default])
-                      (get-in project [:auto task]))]
+  (let [config (->> (merge default-config 
+                           (get-in project [:auto :default])
+                           (get-in project [:auto task]))
+                    (compute-config project))]
     (loop [time 0]
       (Thread/sleep (:wait-time config))
       (if-let [files (->> (mapcat directory-files (:paths config))


### PR DESCRIPTION
Upstreaming some changes from my fork, enabling lein-auto to concatenate Leiningen path selectors, rather than just taking a fixed list of paths. I'm using this to enable using auto against my `:doc-paths`.