### PR TITLE
Reimplement watcher using WatchService

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ There are currently four options available:
   a regular expression that determine which files to watch (defaults
   to `#"\.(clj|cljs|cljx|cljc)$"`).
 
-- `:wait-time` -
-  the time to wait in milliseconds between polling the filesystem
-  (defaults to 50)
-
 - `:log-color` -
   the color of the Lein-Auto log messages (defaults to `:magenta`).
   The following colors are allowed: black gray white red green yellow

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-auto "0.1.4-SNAPSHOT"
+(defproject lein-auto "0.1.3"
   :description "Leiningen plugin that executes tasks when files are modified"
   :url "https://github.com/weavejester/lein-auto"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-auto "0.1.3"
+(defproject lein-auto "0.1.4-SNAPSHOT"
   :description "Leiningen plugin that executes tasks when files are modified"
   :url "https://github.com/weavejester/lein-auto"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/auto.clj
+++ b/src/leiningen/auto.clj
@@ -7,11 +7,8 @@
            [com.sun.nio.file SensitivityWatchEventModifier]
            [java.io File]))
 
-(defn directory-files [dir]
-  (->> (io/file dir) (file-seq) (remove (memfn isDirectory))))
-
-  (defn directory-directories [dir]
-    (->> (io/file dir) (file-seq) (filter (memfn isDirectory))))
+(defn directory-directories [dir]
+  (->> (io/file dir) (file-seq) (filter (memfn isDirectory))))
 
 (defn modified-since [^File file timestamp]
   (> (.lastModified file) timestamp))

--- a/src/leiningen/auto.clj
+++ b/src/leiningen/auto.clj
@@ -38,21 +38,6 @@
   (binding [main/*exit-process?* false]
     (main/resolve-and-apply project (cons task args))))
 
-(defn add-ending-separator [^String path]
-  (if (.endsWith path File/separator)
-    path
-    (str path File/separator)))
-
-(defn remove-prefix [^String s ^String prefix]
-  (if (.startsWith s prefix)
-    (subs s (.length prefix))
-    s))
-
-(defn show-modified [project files]
-  (let [root  (add-ending-separator (:root project))
-        paths (map #(remove-prefix (str %) root) files)]
-    (str/join ", " paths)))
-
 (def default-config
   {:file-pattern #"\.(clj|cljs|cljx|cljc)$"
    :log-color    :magenta})
@@ -105,7 +90,7 @@
           (add-new-directories key events)
           (if (not (empty? modified))
             (do
-              (log config "Files changed:" (str/join " " modified))
+              (log config "Files changed:" (str/join ", " modified))
               (log config "Running: lein" task (str/join " " args))
               (try
                 (run-task project task args)

--- a/src/leiningen/auto.clj
+++ b/src/leiningen/auto.clj
@@ -84,20 +84,20 @@
                         (into-array [StandardWatchEventKinds/ENTRY_CREATE StandardWatchEventKinds/ENTRY_MODIFY StandardWatchEventKinds/ENTRY_DELETE])
                         (into-array [SensitivityWatchEventModifier/HIGH]))]
                     {key dir})))]
-      (log config "booted")
+      (log config "lein-auto now watching:" (:paths config))
       (loop [keys keys]
         (let [key (.take watcher)]
           (if (contains? keys key)
-            (doseq [event (.pollEvents key) :let [fp (str (get keys key) "/" (-> event .context .toString))]]
-              (log config fp))
-          )
-          (.reset key)
-        )
-        (recur keys)
-        )))
-          ; (log config "Running: lein" task (str/join " " args))
-          ; (try
-          ;   (run-task project task args)
-          ;   (log config "Completed.")
-          ;   (catch ExceptionInfo _
-          ;     (log config "Failed."))))))
+            (do
+              (doseq [event (.pollEvents key) :let [fp (str (get keys key) "/" (-> event .context .toString))]]
+                (log config "Changes to:" fp))
+              (log config "Running: lein" task (str/join " " args))
+              (try
+                (run-task project task args)
+                (log config "Completed.")
+                (catch ExceptionInfo _
+                  (log config "Failed.")))
+              (if (.reset key)
+                (recur keys)
+                (recur (dissoc key key))))
+            (recur keys))))))

--- a/src/leiningen/auto.clj
+++ b/src/leiningen/auto.clj
@@ -55,7 +55,6 @@
 
 (def default-config
   {:file-pattern #"\.(clj|cljs|cljx|cljc)$"
-   :wait-time    50
    :log-color    :magenta})
 
 (defn default-paths [project]

--- a/src/leiningen/auto.clj
+++ b/src/leiningen/auto.clj
@@ -52,8 +52,8 @@
 (def watch-service
   (delay (.newWatchService (FileSystems/getDefault))))
 
-(defn full-event-path [watchkey evt]
-  (str (get @watched-dirs watchkey) "/" (-> evt .context .toString)))
+(defn full-event-path [watch-key evt]
+  (str (@watched-dirs watch-key) "/" (-> evt .context .toString)))
 
 (def watch-event-kinds
   (into-array [StandardWatchEventKinds/ENTRY_CREATE
@@ -70,14 +70,14 @@
                         watch-event-modifiers)]
     (swap! watched-dirs assoc key dir)))
 
-(defn add-new-directories [watchkey events]
-  (doseq [evt events :let [dir (io/file (full-event-path watchkey evt))]]
+(defn add-new-directories [watch-key events]
+  (doseq [evt events :let [dir (io/file (full-event-path watch-key evt))]]
     (if (and (= (.kind evt) StandardWatchEventKinds/ENTRY_CREATE)
              (.isDirectory dir))
       (watch-dir! dir))))
 
-(defn modified-files [watchkey events]
-  (map #(full-event-path watchkey %) events))
+(defn modified-files [watch-key events]
+  (map #(full-event-path watch-key %) events))
 
 (defn auto
   "Executes the given task every time a file in the project is modified."


### PR DESCRIPTION
I had a bunch of high CPU situations when running lein-auto under Docker on my Mac recently, and eventually realised the problem was the continuous polling. I reduced the interval a bit, which improved things somewhat, but I was still seeing pretty high numbers. I've now got this, which is a first attempt at reimplementing things using WatchService instead (heavily based off of https://docs.oracle.com/javase/tutorial/essential/io/notification.html)

Any thoughts?