### PR TITLE
Retry on every exception.

### DIFF
--- a/src/leiningen/auto.clj
+++ b/src/leiningen/auto.clj
@@ -80,7 +80,7 @@
           (try
             (run-task project task args)
             (log config "Completed.")
-            (catch ExceptionInfo _
+            (catch Exception _
               (log config "Failed.")))
           (recur time))
         (recur time)))))


### PR DESCRIPTION
Catching `ExceptionInfo` is not enough and the whole `auto` task will
fail if we don't exception `Exception`.
By catching exception, we can let `lein auto` keep trying indefinitely,
even when the task is failing.